### PR TITLE
Fail Tealium helper silently

### DIFF
--- a/tealium_angular.js
+++ b/tealium_angular.js
@@ -57,7 +57,10 @@ angular.module("TealiumHelper", ["TealiumHelper.data"])
     addViewIdMapEntry: tealiumDataProvider.addViewIdMapEntry,
     $get: [ "tealiumData", "$location", function(tealiumData, $location) {
       if (!config.account || !config.profile) {
-        throw new Error("account or profile value not set.  Please configure Tealium first");
+        if (config.account || config.profile) console.warn("Tealium configuration not valid. Please check your account and profile");
+        return {
+          run: function() {}
+        };
       }
 
       this.setConfigValue( "script_src", "//tags.tiqcdn.com/utag/"+ config.account + "/"+ config.profile +"/"+ config.environment + "/utag.js" );

--- a/tealium_angular.js
+++ b/tealium_angular.js
@@ -57,7 +57,7 @@ angular.module("TealiumHelper", ["TealiumHelper.data"])
     addViewIdMapEntry: tealiumDataProvider.addViewIdMapEntry,
     $get: [ "tealiumData", "$location", function(tealiumData, $location) {
       if (!config.account || !config.profile) {
-        if (config.account || config.profile) console.warn("Tealium configuration not valid. Please check your account and profile");
+        if (window.console) console.warn("Tealium configuration not valid. Please check your account and profile");
         return {
           run: function() {}
         };


### PR DESCRIPTION
The approach in the existing module to throw the entire app is fairly aggressive. It means any error with your tealium config will ungracefully break the entire website when the Tealium tracking probably would never be so mission-critical to justify a break that substantial.

This is just a minor suggestion + patch. The code's changed to handle that error differently. If the config object is partially configured, we should log a warning and if there's no configuration we shouldn't run the integration at all.

An alternative would be to always warn instead of the throw, but to keep the console clean – this seems nicest in my opinion!